### PR TITLE
Fix PostHog initialization to handle missing/invalid env vars

### DIFF
--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -3,13 +3,22 @@
 import posthog from "posthog-js";
 import { PostHogProvider } from "posthog-js/react";
 
-if (typeof window !== "undefined") {
-  posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
-    api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+const posthogKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+const posthogHost = process.env.NEXT_PUBLIC_POSTHOG_HOST;
+
+// Only initialize PostHog if we have a valid key (not a placeholder)
+const isValidKey = posthogKey && !posthogKey.includes("your_posthog_key");
+
+if (typeof window !== "undefined" && isValidKey) {
+  posthog.init(posthogKey, {
+    api_host: posthogHost || "https://us.i.posthog.com",
     person_profiles: "identified_only",
   });
 }
 
 export function CSPostHogProvider({ children }: { children: React.ReactNode }) {
+  if (!isValidKey) {
+    return <>{children}</>;
+  }
   return <PostHogProvider client={posthog}>{children}</PostHogProvider>;
 }


### PR DESCRIPTION
- Add validation to check if NEXT_PUBLIC_POSTHOG_KEY is set and not a placeholder
- Skip PostHog initialization entirely when key is missing/invalid
- Return children directly without PostHogProvider wrapper when disabled
- Add fallback api_host URL when NEXT_PUBLIC_POSTHOG_HOST is not set